### PR TITLE
Fix typos and wording + Update French translation accordingly

### DIFF
--- a/data/com.github.dr-styki.screenrec.appdata.xml.in
+++ b/data/com.github.dr-styki.screenrec.appdata.xml.in
@@ -9,9 +9,9 @@
   <summary>Record videos of the screen</summary>
   <description>
     <p>A simple screen recording tool which was make to work like the elementary OS Screenshot tool.</p>
-    <p>Features include:</p>
+    <p>Included features:</p>
     <ul>
-      <li>Recording sound from speakers</li>
+      <li>Recording sound from computer</li>
       <li>Recording sound from microphone</li>
       <li>Available format: MP4, MKV and WEBM</li>
     </ul>
@@ -19,22 +19,22 @@
   <releases>
     <release version="2.1.0" date="2020-06-04">
       <description>
-        <p>Fix unsensitive window if record are canceled. Name change back to ScreenRec.</p>
+        <p>Fix unsensitive window if a record is cancelled. Name changed back to ScreenRec.</p>
       </description>
     </release>
     <release version="2.0.0" date="2020-05-01">
       <description>
-        <p>Application rewite. Use Gstreamer backend instead of FFmpeg. Etc ...</p>
+        <p>Application rewrite. Use GStreamer backend instead of FFmpeg etc.</p>
       </description>
     </release>
     <release version="1.2.0" date="2020-04-11">
       <description>
-        <p>UI Improvements</p>
+        <p>UI improvements</p>
       </description>
     </release>
     <release version="1.1.0" date="2020-04-09">
       <description>
-        <p>First Release after the fork of the screenrecorder app by Mohammed ALMadhoun</p>
+        <p>First release after the fork of the screenrecorder app by Mohammed ALMadhoun</p>
       </description>
     </release>
   </releases>

--- a/po/com.github.dr-styki.screenrec.pot
+++ b/po/com.github.dr-styki.screenrec.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dr-styki.screenrec\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-09 19:52+0200\n"
+"POT-Creation-Date: 2020-06-10 10:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -66,7 +66,7 @@ msgid "Stop Recording"
 msgstr ""
 
 #: src/Dialogs/Countdown.vala:51
-msgid "Recording starts in"
+msgid "Recording starts in…"
 msgstr ""
 
 #: src/Dialogs/ProgressDialog.vala:51
@@ -99,43 +99,43 @@ msgid "Screen record from %s"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:29
-msgid " Start Recording"
+msgid "Recording started"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:30
-msgid " Stop Recording"
+msgid "Recording stopped"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:31
-msgid " Pause Recording"
+msgid "Recording paused"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:32
-msgid " Resume Recording"
+msgid "Recording resumed"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:33
-msgid " Countdown Canceled"
+msgid "Countdown Cancelled"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:40
-msgid " The recording has been started"
+msgid "The recording has been started"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:41
-msgid " The recording is done"
+msgid "The recording is complete"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:42
-msgid " The recording is paused"
+msgid "The recording has been paused"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:43
-msgid " The recording is resumed"
+msgid "The recording has been resumed"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:44
-msgid " The countdown has been canceled"
+msgid "The countdown has been cancelled"
 msgstr ""
 
 #: src/Views/SettingsView.vala:84
@@ -151,11 +151,11 @@ msgid "Record sounds:"
 msgstr ""
 
 #: src/Views/SettingsView.vala:103
-msgid "Record sounds from speakers"
+msgid "Record sound from computer"
 msgstr ""
 
 #: src/Views/SettingsView.vala:120
-msgid "Record sounds from microphone"
+msgid "Record sound from microphone"
 msgstr ""
 
 #: src/Views/SettingsView.vala:143

--- a/po/com.github.dr-styki.screenrec.pot
+++ b/po/com.github.dr-styki.screenrec.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dr-styki.screenrec\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-10 10:11+0200\n"
+"POT-Creation-Date: 2020-06-10 10:20+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,7 +115,7 @@ msgid "Recording resumed"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:33
-msgid "Countdown Cancelled"
+msgid "Countdown cancelled"
 msgstr ""
 
 #: src/Tools/SendNotification.vala:40

--- a/po/extra/extra.pot
+++ b/po/extra/extra.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-09 19:55+0200\n"
+"POT-Creation-Date: 2020-06-10 10:11+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -42,11 +42,11 @@ msgid ""
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:12
-msgid "Features include:"
+msgid "Included features:"
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:14
-msgid "Recording sound from speakers"
+msgid "Recording sound from computer"
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:15
@@ -59,20 +59,21 @@ msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:22
 msgid ""
-"Fix unsensitive window if record are canceled. Name change back to ScreenRec."
+"Fix unsensitive window if a record is cancelled. Name changed back to "
+"ScreenRec."
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:27
-msgid "Application rewite. Use Gstreamer backend instead of FFmpeg. Etc ..."
+msgid "Application rewrite. Use GStreamer backend instead of FFmpeg etc."
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:32
-msgid "UI Improvements"
+msgid "UI improvements"
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:37
 msgid ""
-"First Release after the fork of the screenrecorder app by Mohammed ALMadhoun"
+"First release after the fork of the screenrecorder app by Mohammed ALMadhoun"
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:87

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -1,15 +1,15 @@
 # French translations for extra package.
 # Copyright (C) 2020 THE extra'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the extra package.
-# Automatically generated, 2020.
+# Nathan Bonnemains (@NathanBnm), 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-09 19:55+0200\n"
+"POT-Creation-Date: 2020-06-10 10:11+0200\n"
 "PO-Revision-Date: 2020-06-09 19:51+0200\n"
-"Last-Translator: Automatically generated\n"
+"Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -44,16 +44,16 @@ msgstr ""
 "capture d'écran d'elementary OS."
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:12
-msgid "Features include:"
-msgstr "Les fonctionnalités incluent :"
+msgid "Included features:"
+msgstr "Fonctionnalités incluses :"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:14
-msgid "Recording sound from speakers"
-msgstr "Enregistrer le son depuis les enceintes"
+msgid "Recording sound from computer"
+msgstr "Enregistrement du son de l'ordinateur"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:15
 msgid "Recording sound from microphone"
-msgstr "Enregistrer le son depuis le micro"
+msgstr "Enregistrement du son du microphone"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:16
 msgid "Available format: MP4, MKV and WEBM"
@@ -61,20 +61,25 @@ msgstr "Formats disponibles : MP4, MKV et WEBM"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:22
 msgid ""
-"Fix unsensitive window if record are canceled. Name change back to ScreenRec."
+"Fix unsensitive window if a record is cancelled. Name changed back to "
+"ScreenRec."
 msgstr ""
+"Correction de la sensibilité de la fenêtre si l'enregistrement est annulé. "
+"Changement de nom pour revenir à ScreenRec."
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:27
-msgid "Application rewite. Use Gstreamer backend instead of FFmpeg. Etc ..."
+msgid "Application rewrite. Use GStreamer backend instead of FFmpeg etc."
 msgstr ""
+"Réécriture de l'application. Utilisation du service GStreamer au lieu de "
+"FFmpeg etc."
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:32
-msgid "UI Improvements"
-msgstr "Amélioration de l'interface utilisateur"
+msgid "UI improvements"
+msgstr "Améliorations de l'interface"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:37
 msgid ""
-"First Release after the fork of the screenrecorder app by Mohammed ALMadhoun"
+"First release after the fork of the screenrecorder app by Mohammed ALMadhoun"
 msgstr ""
 "Première publication après le fork de l'application screenrecorder de "
 "Mohammed ALMadhoun"

--- a/po/extra/pt_BR.po
+++ b/po/extra/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-09 19:55+0200\n"
+"POT-Creation-Date: 2020-06-10 10:11+0200\n"
 "PO-Revision-Date: 2020-06-09 19:51+0200\n"
 "Last-Translator: Henrique Andrade <henrique.coelho@gmail.com>\n"
 "Language-Team: none\n"
@@ -44,12 +44,13 @@ msgstr ""
 "semelhante à ferramenta Captura de Tela do elementary OS."
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:12
-msgid "Features include:"
-msgstr "Os recursos incluem:"
+msgid "Included features:"
+msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:14
-msgid "Recording sound from speakers"
-msgstr "Gravação de sons das caixas de som"
+#, fuzzy
+msgid "Recording sound from computer"
+msgstr "Gravação de sons do microfone"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:15
 msgid "Recording sound from microphone"
@@ -61,20 +62,23 @@ msgstr "Formatos disponíveis: MP4, MKV e WEBVM"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:22
 msgid ""
-"Fix unsensitive window if record are canceled. Name change back to ScreenRec."
+"Fix unsensitive window if a record is cancelled. Name changed back to "
+"ScreenRec."
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:27
-msgid "Application rewite. Use Gstreamer backend instead of FFmpeg. Etc ..."
+msgid "Application rewrite. Use GStreamer backend instead of FFmpeg etc."
 msgstr ""
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:32
-msgid "UI Improvements"
+#, fuzzy
+msgid "UI improvements"
 msgstr "Melhorias na interface do usuário"
 
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:37
+#, fuzzy
 msgid ""
-"First Release after the fork of the screenrecorder app by Mohammed ALMadhoun"
+"First release after the fork of the screenrecorder app by Mohammed ALMadhoun"
 msgstr ""
 "Primeiro lançamento após o fork do aplicativo screenrecorder de Mohammed "
 "ALMadhoun"
@@ -82,3 +86,9 @@ msgstr ""
 #: data/com.github.dr-styki.screenrec.appdata.xml.in:87
 msgid "Stevy THOMAS (dr_Styki)"
 msgstr "Stevy THOMAS (dr_Styki)"
+
+#~ msgid "Features include:"
+#~ msgstr "Os recursos incluem:"
+
+#~ msgid "Recording sound from speakers"
+#~ msgstr "Gravação de sons das caixas de som"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,15 +1,15 @@
 # French translations for com.github.dr-styki.screenrec package.
 # Copyright (C) 2020 THE com.github.dr-styki.screenrec'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.dr-styki.screenrec package.
-# Automatically generated, 2020.
+# Nathan Bonnemains (@NathanBnm), 2020.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dr-styki.screenrec\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-09 19:52+0200\n"
+"POT-Creation-Date: 2020-06-10 10:11+0200\n"
 "PO-Revision-Date: 2020-06-09 19:52+0200\n"
-"Last-Translator: Automatically generated\n"
+"Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -23,20 +23,20 @@ msgstr "Enregistrements d'écran"
 
 #: src/ScreenrecorderWindow.vala:78
 msgid "Grab the whole screen"
-msgstr "Sélectionner tout l'écran"
+msgstr "Capturer tout l'écran"
 
 #: src/ScreenrecorderWindow.vala:82
 msgid "Grab the current window"
-msgstr "Sélectionner la fenêtre courante"
+msgstr "Capturer la fenêtre courante"
 
 #: src/ScreenrecorderWindow.vala:86
 msgid "Select area to grab"
-msgstr "Sélectionner une zone"
+msgstr "Capturer une zone"
 
 #: src/ScreenrecorderWindow.vala:106 src/ScreenrecorderWindow.vala:201
 #: src/ScreenrecorderWindow.vala:348
 msgid "Record Screen"
-msgstr "Enregistrer"
+msgstr "Enregistrer l'écran"
 
 #: src/ScreenrecorderWindow.vala:112 src/ScreenrecorderWindow.vala:204
 #: src/ScreenrecorderWindow.vala:351
@@ -50,7 +50,7 @@ msgstr "Reprendre"
 #: src/ScreenrecorderWindow.vala:224 src/ScreenrecorderWindow.vala:338
 #: src/Dialogs/Countdown.vala:94
 msgid "Pause"
-msgstr "Pause"
+msgstr "Mettre en pause"
 
 #: src/ScreenrecorderWindow.vala:326 src/Dialogs/ProgressDialog.vala:60
 #: src/Dialogs/SaveDialog.vala:119
@@ -63,31 +63,31 @@ msgstr "Réduire"
 
 #: src/ScreenrecorderWindow.vala:336 src/Dialogs/Countdown.vala:92
 msgid "Stop Recording"
-msgstr "Stop"
+msgstr "Arrêter l'enregistrement"
 
 #: src/Dialogs/Countdown.vala:51
-msgid "Recording starts in"
-msgstr "L'enregistrement débute dans"
+msgid "Recording starts in…"
+msgstr "L'enregistrement va démarrer dans…"
 
 #: src/Dialogs/ProgressDialog.vala:51
 msgid "Video recording in progress"
-msgstr "Enregistrement de la vidéo en cours"
+msgstr "Capture vidéo en cours"
 
 #: src/Dialogs/SaveDialog.vala:75
 msgid "Save record as…"
-msgstr "Enregistrer comme…"
+msgstr "Enregistrer la capture sous…"
 
 #: src/Dialogs/SaveDialog.vala:79
 msgid "Name:"
-msgstr "Nom:"
+msgstr "Nom :"
 
 #: src/Dialogs/SaveDialog.vala:89
 msgid "Folder:"
-msgstr "Dossier:"
+msgstr "Dossier :"
 
 #: src/Dialogs/SaveDialog.vala:99
 msgid "Select Screen Records Folder…"
-msgstr "Selectionner le dossier d'enregistrement…"
+msgstr "Sélectionner le dossier de destination…"
 
 #: src/Dialogs/SaveDialog.vala:122
 msgid "Save"
@@ -96,120 +96,76 @@ msgstr "Enregistrer"
 #: src/Dialogs/SaveDialog.vala:184
 #, c-format
 msgid "Screen record from %s"
-msgstr "Écran enregistré le %s"
+msgstr "Enregistrement d'écran du %s"
 
 #: src/Tools/SendNotification.vala:29
-msgid " Start Recording"
-msgstr " Enregistrement débuté"
+msgid "Recording started"
+msgstr "Enregistrement démarré"
 
 #: src/Tools/SendNotification.vala:30
-msgid " Stop Recording"
-msgstr " Enregistrement terminé"
+msgid "Recording stopped"
+msgstr "Enregistrement arrêté"
 
 #: src/Tools/SendNotification.vala:31
-msgid " Pause Recording"
-msgstr " Enregistrement interrompu"
+msgid "Recording paused"
+msgstr "Enregistrement mis en pause"
 
 #: src/Tools/SendNotification.vala:32
-msgid " Resume Recording"
-msgstr " Enregistrement reprit"
+msgid "Recording resumed"
+msgstr "Enregistrement repris"
 
 #: src/Tools/SendNotification.vala:33
-msgid " Countdown Canceled"
-msgstr " Compte à rebours annulé"
+msgid "Countdown Cancelled"
+msgstr "Compte à rebours annulé"
 
 #: src/Tools/SendNotification.vala:40
-msgid " The recording has been started"
-msgstr " L'enregistrement a commencé"
+msgid "The recording has been started"
+msgstr "L'enregistrement a démarré"
 
 #: src/Tools/SendNotification.vala:41
-msgid " The recording is done"
-msgstr " L'enregistrement est terminé"
+msgid "The recording is complete"
+msgstr "L'enregistrement est terminé"
 
 #: src/Tools/SendNotification.vala:42
-msgid " The recording is paused"
-msgstr " L'enregistrement est en pause"
+msgid "The recording has been paused"
+msgstr "L'enregistrement a été mis en pause"
 
 #: src/Tools/SendNotification.vala:43
-msgid " The recording is resumed"
-msgstr " L'enregistrement reprend"
+msgid "The recording has been resumed"
+msgstr "L'enregistrement a repris"
 
 #: src/Tools/SendNotification.vala:44
-msgid " The countdown has been canceled"
-msgstr " Le compte à rebours a été annulé"
+msgid "The countdown has been cancelled"
+msgstr "Le compte à rebours a été annulé"
 
 #: src/Views/SettingsView.vala:84
 msgid "Grab mouse pointer:"
-msgstr "Capturer le pointeur:"
+msgstr "Capturer le pointeur de la souris :"
 
 #: src/Views/SettingsView.vala:91
 msgid "Close after saving:"
-msgstr "Fermer après l'enregistrement:"
+msgstr "Fermer après l'enregistrement :"
 
 #: src/Views/SettingsView.vala:98
 msgid "Record sounds:"
-msgstr "Enregistrer le son:"
+msgstr "Enregistrer le son :"
 
 #: src/Views/SettingsView.vala:103
-msgid "Record sounds from speakers"
-msgstr "Enregistrer le son depuis les enceintes"
+msgid "Record sound from computer"
+msgstr "Enregistrer le son de l'ordinateur"
 
 #: src/Views/SettingsView.vala:120
-msgid "Record sounds from microphone"
-msgstr "Enregistrer le son depuis le micro"
+msgid "Record sound from microphone"
+msgstr "Enregistrer le son du microphone"
 
 #: src/Views/SettingsView.vala:143
 msgid "Delay in seconds:"
-msgstr "Délai en secondes:"
+msgstr "Délai en secondes :"
 
 #: src/Views/SettingsView.vala:148
 msgid "Frame rate:"
-msgstr "Images / seconde:"
+msgstr "Images par seconde :"
 
 #: src/Views/SettingsView.vala:153
 msgid "Format:"
-msgstr "Format:"
-
-#~ msgid "Screen Recorder"
-#~ msgstr "Enregistreur d'écran"
-
-#~ msgid "Record videos of the screen"
-#~ msgstr "Enregistrer des vidéos de l'écran"
-
-#~ msgid ""
-#~ "A simple screen recording tool which was make to work like the elementary "
-#~ "OS Screenshot tool."
-#~ msgstr ""
-#~ "Un outil d'enregistrement d'écran conçu pour fonctionner comme l'outil de "
-#~ "capture d'écran d'elementary OS."
-
-#~ msgid "Features include:"
-#~ msgstr "Les fonctionnalités inclues:"
-
-#~ msgid "Recording sound from speakers"
-#~ msgstr "Enregistrer le son depuis les enceintes"
-
-#~ msgid "Recording sound from microphone"
-#~ msgstr "Enregistrer le son depuis le micro"
-
-#~ msgid "Available format: MP4 and WEBM"
-#~ msgstr "Formats disponibles: MP4, MKV et WEBM"
-
-#~ msgid "UI Improvements"
-#~ msgstr "Amélioration de l'interface utilisateur"
-
-#~ msgid ""
-#~ "First Release after the fork of the screenrecorder app by Mohammed "
-#~ "ALMadhoun"
-#~ msgstr ""
-#~ "Première publication après le fork de l'application screenrecorder de "
-#~ "Mohammed ALMadhoun"
-
-#~ msgid "Stevy THOMAS (dr_Styki)"
-#~ msgstr "Stevy THOMAS (dr_Styki)"
-
-#~ msgid "com.github.dr-styki.screenrec"
-#~ msgstr "com.github.dr-styki.screenrec"
-
-#~ msgid "Screenshot;Screen;Record;Recording;"
-#~ msgstr "Screenshot;Screen;Record;Recording;"
+msgstr "Format :"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dr-styki.screenrec\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-10 10:11+0200\n"
+"POT-Creation-Date: 2020-06-10 10:20+0200\n"
 "PO-Revision-Date: 2020-06-09 19:52+0200\n"
 "Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: none\n"
@@ -115,7 +115,7 @@ msgid "Recording resumed"
 msgstr "Enregistrement repris"
 
 #: src/Tools/SendNotification.vala:33
-msgid "Countdown Cancelled"
+msgid "Countdown cancelled"
 msgstr "Compte à rebours annulé"
 
 #: src/Tools/SendNotification.vala:40

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dr-styki.screenrec\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-09 19:52+0200\n"
+"POT-Creation-Date: 2020-06-10 10:11+0200\n"
 "PO-Revision-Date: 2020-06-09 19:52+0200\n"
 "Last-Translator: Henrique Andrade <henrique.coelho@gmail.com>\n"
 "Language-Team: none\n"
@@ -66,7 +66,8 @@ msgid "Stop Recording"
 msgstr "Parar gravação"
 
 #: src/Dialogs/Countdown.vala:51
-msgid "Recording starts in"
+#, fuzzy
+msgid "Recording starts in…"
 msgstr "A gravação começa em"
 
 #: src/Dialogs/ProgressDialog.vala:51
@@ -99,43 +100,53 @@ msgid "Screen record from %s"
 msgstr "Gravação de tela de %s"
 
 #: src/Tools/SendNotification.vala:29
-msgid " Start Recording"
-msgstr " Iniciar gravação"
+#, fuzzy
+msgid "Recording started"
+msgstr "A gravação começa em"
 
 #: src/Tools/SendNotification.vala:30
-msgid " Stop Recording"
-msgstr " Parar gravação"
+#, fuzzy
+msgid "Recording stopped"
+msgstr " Gravação pausada"
 
 #: src/Tools/SendNotification.vala:31
-msgid " Pause Recording"
-msgstr " Pausar gravação"
+#, fuzzy
+msgid "Recording paused"
+msgstr " Gravação pausada"
 
 #: src/Tools/SendNotification.vala:32
-msgid " Resume Recording"
-msgstr " Retomar gravação"
+#, fuzzy
+msgid "Recording resumed"
+msgstr " Gravação retomada"
 
 #: src/Tools/SendNotification.vala:33
-msgid " Countdown Canceled"
+#, fuzzy
+msgid "Countdown Cancelled"
 msgstr " Contagem regressiva cancelada"
 
 #: src/Tools/SendNotification.vala:40
-msgid " The recording has been started"
+#, fuzzy
+msgid "The recording has been started"
 msgstr " Gravação iniciada"
 
 #: src/Tools/SendNotification.vala:41
-msgid " The recording is done"
+#, fuzzy
+msgid "The recording is complete"
 msgstr " Gravação concluída"
 
 #: src/Tools/SendNotification.vala:42
-msgid " The recording is paused"
+#, fuzzy
+msgid "The recording has been paused"
 msgstr " Gravação pausada"
 
 #: src/Tools/SendNotification.vala:43
-msgid " The recording is resumed"
+#, fuzzy
+msgid "The recording has been resumed"
 msgstr " Gravação retomada"
 
 #: src/Tools/SendNotification.vala:44
-msgid " The countdown has been canceled"
+#, fuzzy
+msgid "The countdown has been cancelled"
 msgstr "  A contagem regressiva foi cancelada"
 
 #: src/Views/SettingsView.vala:84
@@ -151,11 +162,13 @@ msgid "Record sounds:"
 msgstr "Gravar sons:"
 
 #: src/Views/SettingsView.vala:103
-msgid "Record sounds from speakers"
-msgstr "Gravar sons do computador"
+#, fuzzy
+msgid "Record sound from computer"
+msgstr "Gravar sons do microfone"
 
 #: src/Views/SettingsView.vala:120
-msgid "Record sounds from microphone"
+#, fuzzy
+msgid "Record sound from microphone"
 msgstr "Gravar sons do microfone"
 
 #: src/Views/SettingsView.vala:143
@@ -169,6 +182,24 @@ msgstr "Taxa de quadros (FPS):"
 #: src/Views/SettingsView.vala:153
 msgid "Format:"
 msgstr "Formato:"
+
+#, fuzzy
+#~ msgid "Start Recording"
+#~ msgstr " Iniciar gravação"
+
+#, fuzzy
+#~ msgid "Pause Recording"
+#~ msgstr " Pausar gravação"
+
+#, fuzzy
+#~ msgid "Resume Recording"
+#~ msgstr " Retomar gravação"
+
+#~ msgid " Stop Recording"
+#~ msgstr " Parar gravação"
+
+#~ msgid "Record sounds from speakers"
+#~ msgstr "Gravar sons do computador"
 
 #~ msgid "Screen Recorder"
 #~ msgstr "Gravador de Tela"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.dr-styki.screenrec\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-10 10:11+0200\n"
+"POT-Creation-Date: 2020-06-10 10:20+0200\n"
 "PO-Revision-Date: 2020-06-09 19:52+0200\n"
 "Last-Translator: Henrique Andrade <henrique.coelho@gmail.com>\n"
 "Language-Team: none\n"
@@ -121,7 +121,7 @@ msgstr " Gravação retomada"
 
 #: src/Tools/SendNotification.vala:33
 #, fuzzy
-msgid "Countdown Cancelled"
+msgid "Countdown cancelled"
 msgstr " Contagem regressiva cancelada"
 
 #: src/Tools/SendNotification.vala:40

--- a/src/Dialogs/Countdown.vala
+++ b/src/Dialogs/Countdown.vala
@@ -48,7 +48,7 @@ namespace ScreenRec {
             box.margin_end = 40;
             box.margin_top = box.margin_bottom = 20;
 
-            var title = new Gtk.Label ("<span size='20000'>" + _("Recording starts in") + "…" + "</span>");
+            var title = new Gtk.Label ("<span size='20000'>" + _("Recording starts in…") + "</span>");
             title.use_markup = true;
             title.margin_bottom = 10;
 

--- a/src/Tools/SendNotification.vala
+++ b/src/Tools/SendNotification.vala
@@ -30,7 +30,7 @@ namespace ScreenRec {
         private Notification stop_notification = new Notification (_("Recording stopped"));
         private Notification pause_notification = new Notification (_("Recording paused"));
         private Notification resume_notification = new Notification (_("Recording resumed"));
-        private Notification cancel_cd_notification = new Notification (_("Countdown Cancelled"));
+        private Notification cancel_cd_notification = new Notification (_("Countdown cancelled"));
         
 
         public SendNotification (Gtk.ApplicationWindow? app) {

--- a/src/Tools/SendNotification.vala
+++ b/src/Tools/SendNotification.vala
@@ -26,22 +26,22 @@ namespace ScreenRec {
         private Gtk.ApplicationWindow app;
         private string app_id = "com.github.dr-styki.ScreenRec";
 
-        private Notification start_notification = new Notification (_(" Start Recording"));
-        private Notification stop_notification = new Notification (_(" Stop Recording"));
-        private Notification pause_notification = new Notification (_(" Pause Recording"));
-        private Notification resume_notification = new Notification (_(" Resume Recording"));
-        private Notification cancel_cd_notification = new Notification (_(" Countdown Canceled"));
+        private Notification start_notification = new Notification (_("Recording started"));
+        private Notification stop_notification = new Notification (_("Recording stopped"));
+        private Notification pause_notification = new Notification (_("Recording paused"));
+        private Notification resume_notification = new Notification (_("Recording resumed"));
+        private Notification cancel_cd_notification = new Notification (_("Countdown Cancelled"));
         
 
         public SendNotification (Gtk.ApplicationWindow? app) {
 
             this.app = app;
 
-            start_notification.set_body (_(" The recording has been started"));
-            stop_notification.set_body (_(" The recording is done"));
-            pause_notification.set_body (_(" The recording is paused"));
-            resume_notification.set_body (_(" The recording is resumed"));
-            cancel_cd_notification.set_body (_(" The countdown has been canceled"));
+            start_notification.set_body (_("The recording has been started"));
+            stop_notification.set_body (_("The recording is complete"));
+            pause_notification.set_body (_("The recording has been paused"));
+            resume_notification.set_body (_("The recording has been resumed"));
+            cancel_cd_notification.set_body (_("The countdown has been cancelled"));
 
         }
         

--- a/src/Views/SettingsView.vala
+++ b/src/Views/SettingsView.vala
@@ -100,7 +100,7 @@ namespace ScreenRec {
 
                 // From Speakers
             record_speakers_btn = new Gtk.CheckButton ();
-            record_speakers_btn.tooltip_text = _("Record sounds from speakers");
+            record_speakers_btn.tooltip_text = _("Record sound from computer");
             record_speakers_btn.toggled.connect(() => {
                 speakers_record = !speakers_record;
                 if (speakers_record) {
@@ -117,7 +117,7 @@ namespace ScreenRec {
 
                 // From Mic
             record_mic_btn = new Gtk.CheckButton ();
-            record_mic_btn.tooltip_text = _("Record sounds from microphone");
+            record_mic_btn.tooltip_text = _("Record sound from microphone");
             record_mic_btn.toggled.connect(() => {
                 mic_record = !mic_record;
                 if (mic_record) {


### PR DESCRIPTION
There were some typos or wrong wordings across the app so here is a small fix. I also updated French translation.

Note: "Record sound from computer" is more accurate than "from speakers" that's why I changed this wording. Otherwise these are just fixes.